### PR TITLE
Potential fix for code scanning alert no. 1: Uncontrolled data used in path expression

### DIFF
--- a/internal/jobsource/file.go
+++ b/internal/jobsource/file.go
@@ -66,30 +66,50 @@ func (s *FileStrategy) Fetch(_ context.Context, u *url.URL) (string, error) {
 		return "", fmt.Errorf("file URL path must be absolute")
 	}
 
+	if s.baseDir == "" {
+		return "", fmt.Errorf("file strategy has no base directory configured")
+	}
+
 	// Ensure that the requested path is within the configured base directory.
 	absPath, err := filepath.Abs(path)
 	if err != nil {
 		return "", fmt.Errorf("invalid file path %q: %w", path, err)
-	absPath = filepath.Clean(absPath)
-	// Enforce that absPath is inside s.baseDir.
-	base := s.baseDir
-	// Ensure base has a trailing separator when doing prefix comparison.
-	if !strings.HasSuffix(base, string(os.PathSeparator)) {
-		base = base + string(os.PathSeparator)
 	}
-	pathWithSep := absPath
+	absPath = filepath.Clean(absPath)
+
+	// Resolve symlinks on the requested path so that a symlink inside baseDir
+	// that points outside cannot bypass the containment check.
+	realPath, err := filepath.EvalSymlinks(absPath)
+	if err != nil {
+		return "", fmt.Errorf("cannot resolve symlinks for file path %q: %w", absPath, err)
+	}
+	realPath = filepath.Clean(realPath)
+
+	// Also resolve symlinks on the base directory itself.
+	realBase, err := filepath.EvalSymlinks(s.baseDir)
+	if err != nil {
+		return "", fmt.Errorf("cannot resolve symlinks for base directory %q: %w", s.baseDir, err)
+	}
+	realBase = filepath.Clean(realBase)
+
+	// Enforce that realPath is inside realBase.
+	// Trailing separators are added to both sides to prevent a directory named
+	// with the same prefix (e.g. /safe/dir-evil vs /safe/dir) from matching.
+	base := realBase
+	if !strings.HasSuffix(base, string(os.PathSeparator)) {
+		base += string(os.PathSeparator)
+	}
+	pathWithSep := realPath
 	if !strings.HasSuffix(pathWithSep, string(os.PathSeparator)) {
-		pathWithSep = pathWithSep + string(os.PathSeparator)
+		pathWithSep += string(os.PathSeparator)
 	}
 	if !strings.HasPrefix(pathWithSep, base) {
 		return "", fmt.Errorf("file URL path %q is outside the allowed directory", absPath)
 	}
 
-	data, err := os.ReadFile(absPath)
+	data, err := os.ReadFile(realPath)
 	if err != nil {
-		return "", fmt.Errorf("read file %q: %w", absPath, err)
-	}
-
+		return "", fmt.Errorf("read file %q: %w", realPath, err)
 	}
 
 	return strings.TrimSpace(string(data)), nil

--- a/internal/jobsource/file_test.go
+++ b/internal/jobsource/file_test.go
@@ -41,7 +41,8 @@ func TestFileStrategyFetch(t *testing.T) {
 		t.Fatalf("parse URL: %v", err)
 	}
 
-	got, err := NewFileStrategy().Fetch(context.Background(), u)
+	s := &FileStrategy{baseDir: dir}
+	got, err := s.Fetch(context.Background(), u)
 	if err != nil {
 		t.Fatalf("Fetch returned error: %v", err)
 	}
@@ -49,6 +50,28 @@ func TestFileStrategyFetch(t *testing.T) {
 	want := strings.TrimSpace(content)
 	if got != want {
 		t.Fatalf("Fetch = %q, want %q", got, want)
+	}
+}
+
+func TestFileStrategyFetchOutsideBaseDir(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	outsideFile := filepath.Join(t.TempDir(), "secret.txt")
+	if err := os.WriteFile(outsideFile, []byte("secret"), 0o644); err != nil {
+		t.Fatalf("write test file: %v", err)
+	}
+
+	rawURL := "file://" + filepath.ToSlash(outsideFile)
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		t.Fatalf("parse URL: %v", err)
+	}
+
+	s := &FileStrategy{baseDir: dir}
+	_, err = s.Fetch(context.Background(), u)
+	if err == nil {
+		t.Fatalf("expected error for path outside base dir")
 	}
 }
 
@@ -63,5 +86,103 @@ func TestFileStrategyFetchUnsupportedHost(t *testing.T) {
 	_, err = NewFileStrategy().Fetch(context.Background(), u)
 	if err == nil {
 		t.Fatalf("expected error for unsupported host")
+	}
+}
+
+// TestFileStrategyFetchPathTraversal verifies that the path-traversal
+// protections in Fetch block all common attack vectors.
+func TestFileStrategyFetchPathTraversal(t *testing.T) {
+	t.Parallel()
+
+	// safeDir is the only directory that should be accessible.
+	safeDir := t.TempDir()
+	// outsideDir is a sibling directory that must not be reachable.
+	outsideDir := t.TempDir()
+
+	// siblingDir has the same string prefix as safeDir (e.g. /tmp/TestXxx/001-evil
+	// when safeDir is /tmp/TestXxx/001) to exercise the trailing-separator guard.
+	siblingDir := safeDir + "-evil"
+	if err := os.MkdirAll(siblingDir, 0o755); err != nil {
+		t.Fatalf("create sibling dir: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(siblingDir) })
+
+	for _, dir := range []string{outsideDir, siblingDir} {
+		if err := os.WriteFile(filepath.Join(dir, "secret.txt"), []byte("secret"), 0o644); err != nil {
+			t.Fatalf("write secret file: %v", err)
+		}
+	}
+
+	// symlinkPath is inside safeDir but points to a file in outsideDir.
+	symlinkPath := filepath.Join(safeDir, "link.txt")
+	if err := os.Symlink(filepath.Join(outsideDir, "secret.txt"), symlinkPath); err != nil {
+		t.Fatalf("create symlink: %v", err)
+	}
+
+	s := &FileStrategy{baseDir: safeDir}
+
+	tests := []struct {
+		name string
+		// rawURL is built as a string so we can include raw %-escapes.
+		rawURL string
+	}{
+		{
+			name:   "absolute path to /etc/passwd",
+			rawURL: "file:///etc/passwd",
+		},
+		{
+			name:   "dot-dot traversal to sibling dir",
+			rawURL: "file://" + filepath.ToSlash(filepath.Join(safeDir, "..", filepath.Base(outsideDir), "secret.txt")),
+		},
+		{
+			name: "URL-encoded dot-dot traversal",
+			rawURL: "file://" + filepath.ToSlash(safeDir) + "/%2e%2e/" +
+				filepath.Base(outsideDir) + "/secret.txt",
+		},
+		{
+			name:   "same-prefix sibling directory",
+			rawURL: "file://" + filepath.ToSlash(filepath.Join(siblingDir, "secret.txt")),
+		},
+		{
+			name:   "symlink inside base dir pointing outside",
+			rawURL: "file://" + filepath.ToSlash(symlinkPath),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			u, err := url.Parse(tc.rawURL)
+			if err != nil {
+				t.Fatalf("parse URL %q: %v", tc.rawURL, err)
+			}
+
+			_, err = s.Fetch(context.Background(), u)
+			if err == nil {
+				t.Fatalf("Fetch(%q) succeeded; expected an error blocking path traversal", tc.rawURL)
+			}
+		})
+	}
+}
+
+func TestFileStrategyFetchEmptyBaseDir(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "job.txt")
+	if err := os.WriteFile(filePath, []byte("content"), 0o644); err != nil {
+		t.Fatalf("write test file: %v", err)
+	}
+
+	u, err := url.Parse("file://" + filepath.ToSlash(filePath))
+	if err != nil {
+		t.Fatalf("parse URL: %v", err)
+	}
+
+	s := &FileStrategy{} // zero value: baseDir is empty
+	_, err = s.Fetch(context.Background(), u)
+	if err == nil {
+		t.Fatalf("expected error for empty baseDir")
 	}
 }

--- a/internal/jobsource/resolver_test.go
+++ b/internal/jobsource/resolver_test.go
@@ -72,7 +72,7 @@ func TestResolverResolveFileURL(t *testing.T) {
 		t.Fatalf("write test file: %v", err)
 	}
 
-	r := NewResolver(NewFileStrategy())
+	r := NewResolver(&FileStrategy{baseDir: dir})
 	rawURL := "file://" + filepath.ToSlash(filePath)
 
 	got, err := r.Resolve(context.Background(), rawURL)


### PR DESCRIPTION
Potential fix for [https://github.com/ansg191/job-temporal/security/code-scanning/1](https://github.com/ansg191/job-temporal/security/code-scanning/1)

In general, to fix this issue you must restrict which filesystem locations can be read via `file://` URLs, instead of allowing arbitrary absolute paths supplied by the user. The common pattern is to define a base “safe directory”, resolve the user-supplied path against it, normalize to an absolute path, and then ensure the final path is still inside the safe directory before reading the file. This prevents directory traversal and reading sensitive files elsewhere on the system.

The best way to fix the problem here, without changing how the rest of the code works, is to add a safe base directory for `FileStrategy` (for example, taken from an environment variable, with a sensible default), compute an absolute path for both the base directory and the requested file, and verify that the requested file path has the base directory as a prefix. If the check fails, return an error instead of reading the file. The `Fetch` method already requires an absolute path, so we can normalize and then apply the “within base dir” check. We will implement this entirely within `internal/jobsource/file.go`.

Concretely:

- Add a `baseDir` field to `FileStrategy`.
- In `NewFileStrategy`, determine the base directory from an environment variable like `JOB_FILE_BASE_DIR`. If not set, default to the current working directory (`os.Getwd()`), and finally fall back to `/` if everything else fails. Normalize it with `filepath.Abs` and `filepath.Clean`.
- In `Fetch`, after deriving `path`, join it to the base directory (or, since `path` is absolute, just compute its absolute/clean form) and then ensure that the resolved path is within `baseDir` (using `filepath.Abs` and a prefix check on the cleaned absolute paths, taking care of path separator boundaries).
- Only call `os.ReadFile` if the path passes the check; otherwise return a clear error.

We only need to modify `internal/jobsource/file.go`. Existing imports already include `os`, `filepath`, and `strings`, so no new imports are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
